### PR TITLE
Light mode only

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,8 +9,7 @@
     <link rel="stylesheet" href="stylesheets/style.css">
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="theme-color" content="#FAFAF7" media="(prefers-color-scheme: light)">
-    <meta name="theme-color" content="#101113" media="(prefers-color-scheme: dark)">
+    <meta name="theme-color" content="#FAFAF7">
   </head>
   <body>
     <div class="wrapper">
@@ -90,11 +89,6 @@
           <a href="projects.html" id="projects">projects</a>
           <a href="mailto:me@kevinlau.me" class="email">email</a>
         </nav>
-        <div class="theme-toggle" role="group" aria-label="Theme">
-          <button type="button" data-theme="auto" aria-pressed="true">auto</button>
-          <button type="button" data-theme="light" aria-pressed="false">light</button>
-          <button type="button" data-theme="dark" aria-pressed="false">dark</button>
-        </div>
       </footer>
     </div>
 

--- a/javascripts/main.js
+++ b/javascripts/main.js
@@ -4,49 +4,6 @@ console.log("Hey there. Welcome to my site. Hope you're having a good day.");
 (function () {
   'use strict';
 
-  // ---- theme toggle ----
-  // States: 'auto' (follow system), 'light', 'dark'.
-  // Persisted in localStorage as 'theme'.
-  const root = document.documentElement;
-  const STORE_KEY = 'theme';
-
-  function applyTheme(value) {
-    if (value === 'light' || value === 'dark') {
-      root.setAttribute('data-theme', value);
-    } else {
-      root.removeAttribute('data-theme');
-    }
-    document.querySelectorAll('.theme-toggle button').forEach((btn) => {
-      btn.setAttribute('aria-pressed', btn.dataset.theme === value ? 'true' : 'false');
-    });
-  }
-
-  function readTheme() {
-    try {
-      const v = localStorage.getItem(STORE_KEY);
-      return v === 'light' || v === 'dark' || v === 'auto' ? v : 'auto';
-    } catch (_) {
-      return 'auto';
-    }
-  }
-
-  function saveTheme(value) {
-    try {
-      localStorage.setItem(STORE_KEY, value);
-    } catch (_) { /* localStorage may be blocked */ }
-  }
-
-  // Initial paint: apply persisted theme before user can see the page.
-  applyTheme(readTheme());
-
-  document.querySelectorAll('.theme-toggle button').forEach((btn) => {
-    btn.addEventListener('click', () => {
-      const next = btn.dataset.theme;
-      saveTheme(next);
-      applyTheme(next);
-    });
-  });
-
   // ---- click-to-copy email ----
   document.querySelectorAll('a.email').forEach((link) => {
     link.addEventListener('click', (ev) => {

--- a/projects.html
+++ b/projects.html
@@ -8,8 +8,7 @@
 
     <link rel="stylesheet" href="stylesheets/style.css">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="theme-color" content="#FAFAF7" media="(prefers-color-scheme: light)">
-    <meta name="theme-color" content="#101113" media="(prefers-color-scheme: dark)">
+    <meta name="theme-color" content="#FAFAF7">
   </head>
   <body>
     <div class="wrapper">
@@ -64,11 +63,6 @@
 
       <footer>
         <p class="manifesto">Don't forget to smile.</p>
-        <div class="theme-toggle" role="group" aria-label="Theme">
-          <button type="button" data-theme="auto" aria-pressed="true">auto</button>
-          <button type="button" data-theme="light" aria-pressed="false">light</button>
-          <button type="button" data-theme="dark" aria-pressed="false">dark</button>
-        </div>
       </footer>
     </div>
 

--- a/stylesheets/style.css
+++ b/stylesheets/style.css
@@ -13,46 +13,13 @@
   --gap: 1.75rem;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --bg: #101113;
-    --fg: #E8E6E0;
-    --muted: #8C9094;
-    --faint: #5A5E62;
-    --hairline: #22252A;
-    --accent: #A4D8BD;
-    --accent-soft: rgba(164, 216, 189, 0.14);
-  }
-}
-
-/* explicit theme overrides via JS */
-:root[data-theme="light"] {
-  --bg: #FAFAF7;
-  --fg: #1F2122;
-  --muted: #80858A;
-  --faint: #B2B5B8;
-  --hairline: #E8E5DD;
-  --accent: #86C7A8;
-  --accent-soft: rgba(134, 199, 168, 0.18);
-}
-
-:root[data-theme="dark"] {
-  --bg: #101113;
-  --fg: #E8E6E0;
-  --muted: #8C9094;
-  --faint: #5A5E62;
-  --hairline: #22252A;
-  --accent: #A4D8BD;
-  --accent-soft: rgba(164, 216, 189, 0.14);
-}
-
 * {
   box-sizing: border-box;
 }
 
 html {
   -webkit-text-size-adjust: 100%;
-  color-scheme: light dark;
+  color-scheme: light;
 }
 
 body {
@@ -302,61 +269,12 @@ footer {
 }
 
 .socials a + a::before {
-  content: '·';
+  content: '\00B7';
   color: var(--faint);
   position: absolute;
   left: -0.55rem;
   top: 0;
   pointer-events: none;
-}
-
-/* ---------- theme toggle ---------- */
-
-.theme-toggle {
-  display: inline-flex;
-  gap: 0;
-  font-family: 'JetBrains Mono', ui-monospace, monospace;
-  font-size: 0.7rem;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  align-self: flex-start;
-}
-
-.theme-toggle button {
-  background: transparent;
-  border: 1px solid var(--hairline);
-  color: var(--muted);
-  padding: 0.35rem 0.65rem;
-  cursor: pointer;
-  font: inherit;
-  letter-spacing: inherit;
-  text-transform: inherit;
-  transition: color 0.18s ease, border-color 0.18s ease, background-color 0.18s ease;
-  margin-left: -1px;
-}
-
-.theme-toggle button:first-child {
-  margin-left: 0;
-  border-top-left-radius: 4px;
-  border-bottom-left-radius: 4px;
-}
-
-.theme-toggle button:last-child {
-  border-top-right-radius: 4px;
-  border-bottom-right-radius: 4px;
-}
-
-.theme-toggle button:hover {
-  color: var(--fg);
-  border-color: var(--faint);
-}
-
-.theme-toggle button[aria-pressed="true"] {
-  color: var(--fg);
-  background: var(--accent-soft);
-  border-color: var(--accent);
-  position: relative;
-  z-index: 1;
 }
 
 /* ---------- copied confirmation ---------- */
@@ -438,7 +356,6 @@ footer {
     padding: 0.5in;
     max-width: none;
   }
-  .theme-toggle,
   .dot {
     display: none;
   }


### PR DESCRIPTION
## Summary
Locks the site to light mode and removes the theme toggle.

- Drops the `@media (prefers-color-scheme: dark)` block and the `:root[data-theme]` overrides
- Removes the `auto · light · dark` toggle UI from both pages and its JS state machine
- Sets `color-scheme: light` so browsers don't apply dark styling to form controls
- Keeps the click-to-copy email behavior in `main.js`
- Drive-by: replaces the literal `·` middle-dot in the social-row CSS separator with the Unicode escape `\00B7`. The literal was rendering as mojibake (`Â·`) when the stylesheet was served without an explicit charset declaration. Escape is encoding-independent.

## Test plan
- [x] Page renders in light mode regardless of system color scheme
- [x] No theme toggle visible
- [x] Social row separators render as middle dots
- [x] Click-to-copy email still works
- [x] No console errors
- [ ] Verify on `https://www.kevinlau.me` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)