### PR TITLE
noindex /dash

### DIFF
--- a/dash/index.html
+++ b/dash/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="robots" content="noindex" />
   <title>priorities</title>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />


### PR DESCRIPTION
## Summary
- Adds `<meta name="robots" content="noindex" />` to [dash/index.html](dash/index.html) so search engines skip the page
- Page is unlinked from the main site, but noindex prevents indexing if anyone links to it externally

## Test plan
- [ ] After merge, view-source on `https://www.kevinlau.me/dash` and confirm the noindex meta is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)